### PR TITLE
Enable react-hot-loader HMR

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -41,6 +41,7 @@
     "@babel/plugin-proposal-function-sent",
     "@babel/plugin-proposal-export-namespace-from",
     "@babel/plugin-proposal-numeric-separator",
-    "@babel/plugin-proposal-throw-expressions"
+    "@babel/plugin-proposal-throw-expressions",
+    "react-hot-loader/babel"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-diff-viewer": "^1.0.4",
     "react-dom": "^16.6.0",
     "react-emotion": "^9.2.12",
+    "react-hot-loader": "^4.6.0",
     "react-router-dom": "^4.3.1",
     "react-spring": "^6.1.0",
     "slate": "^0.44.6",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,32 +1,16 @@
 import React from 'react'
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
+import { BrowserRouter as Router } from 'react-router-dom'
 import { Provider } from 'mobx-react'
 import { injectGlobal } from 'react-emotion'
 import decode from 'jwt-decode'
 
-/* Import Components Start */
-import Header from 'Components/Header'
-import PrivateRoute from 'Components/PrivateRoute'
-import PublicRoute from 'Components/PublicRoute'
+/* Import Hot Routes */
+import Routes from '../hot-routes'
+/* Import Other  */
+import TR from '../assets/fonts/Theinhardt-Regular.woff'
+import TB from '../assets/fonts/Theinhardt-Bold.woff'
+
 import ToastProvider from 'Components/Toast/ToastProvider'
-import { Wrapper, Container } from '_system/Container'
-/* Import Pages Start */
-import Register from 'Pages/Register'
-import Login from 'Pages/Login'
-import Home from 'Pages/Home'
-import MyStories from 'Pages/MyStories'
-import Contributions from 'Pages/Contributions'
-import ProfileSettings from 'Pages/ProfileSettings'
-import CreateStory from 'Pages/CreateStory'
-import EditStory from 'Pages/EditStory'
-import ViewStory from 'Pages/ViewStory'
-import ViewRevision from 'Pages/ViewRevision'
-import ViewRevisions from 'Pages/ViewRevisions'
-import ViewFork from 'Pages/ViewFork'
-import ViewClone from 'Pages/ViewClone'
-import DiffReview from 'Pages/DiffReview'
-import Choose from 'Pages/Choose'
-import Community from 'Pages/Community'
 /* Import Stores Start */
 import UserStore from 'Stores/User'
 import AuthStore from 'Stores/Auth'
@@ -35,9 +19,6 @@ import StoryStore from 'Stores/Story'
 import ContributionsStore from 'Stores/Contributions'
 import CommunityStore from 'Stores/Community'
 import ToastStore from 'Stores/Toasts'
-
-import TR from '../assets/fonts/Theinhardt-Regular.woff'
-import TB from '../assets/fonts/Theinhardt-Bold.woff'
 
 // eslint-disable-next-line
 injectGlobal`
@@ -122,37 +103,7 @@ const App = () => (
     <>
       <ToastProvider />
       <Router>
-        <>
-          <Header />
-          <Wrapper>
-            <Container>
-              <Switch>
-                <PublicRoute exact path="/login" redirectTo="/home" component={Login} />
-                <PublicRoute exact path="/register" redirectTo="/home" component={Register} />
-
-                <PrivateRoute exact path="/home" redirectTo="/login" component={Home} />
-
-                <PrivateRoute exact path="/~:name" redirectTo="/login" component={Community} />
-
-                <PrivateRoute exact path="/story/preview/fork/:id" redirectTo="/login" component={ViewStory} />
-                <PrivateRoute exact path="/story/preview/clone/:id" redirectTo="/login" component={ViewStory} />
-                <PrivateRoute exact path="/story/preview/:id" redirectTo="/login" component={ViewStory} />
-                <PrivateRoute exact path="/story/revisions/:storyId/" redirectTo="/login" component={ViewRevisions} />
-                <PrivateRoute exact path="/story/revisions/:storyId/:revisionId" redirectTo="/login" component={ViewRevision} />
-
-                <PrivateRoute exact path="/story/create" redirectTo="/login" component={CreateStory} />
-                <PrivateRoute exact path="/story/edit/:id" redirectTo="/login" component={EditStory} />
-
-                <PrivateRoute exact path="/start" redirectTo="/login" component={Choose} />
-
-                <PrivateRoute exact path="/profile" redirectTo="/login" component={MyStories} />
-                <PrivateRoute exact path="/profile/settings" redirectTo="/login" component={ProfileSettings} />
-                <PrivateRoute exact path="/profile/contributions" redirectTo="/login" component={Contributions} />
-                <PrivateRoute exact path="/profile/contributions/diff/:id" redirectTo="/login" component={DiffReview} />
-              </Switch>
-            </Container>
-          </Wrapper>
-        </>
+        <Routes />
       </Router>
     </>
   </Provider>

--- a/src/hot-routes.js
+++ b/src/hot-routes.js
@@ -1,0 +1,5 @@
+import { hot } from 'react-hot-loader'
+
+import Routes from './routes'
+
+export default hot(module)(Routes)

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Switch } from 'react-router-dom'
+
+/* Import Components Start */
+import Header from 'Components/Header'
+import PrivateRoute from 'Components/PrivateRoute'
+import PublicRoute from 'Components/PublicRoute'
+import { Wrapper, Container } from '_system/Container'
+/* Import Pages Start */
+import Register from 'Pages/Register'
+import Login from 'Pages/Login'
+import Home from 'Pages/Home'
+import MyStories from 'Pages/MyStories'
+import Contributions from 'Pages/Contributions'
+import ProfileSettings from 'Pages/ProfileSettings'
+import CreateStory from 'Pages/CreateStory'
+import EditStory from 'Pages/EditStory'
+import ViewStory from 'Pages/ViewStory'
+import ViewRevision from 'Pages/ViewRevision'
+import ViewRevisions from 'Pages/ViewRevisions'
+import ViewFork from 'Pages/ViewFork'
+import ViewClone from 'Pages/ViewClone'
+import DiffReview from 'Pages/DiffReview'
+import Choose from 'Pages/Choose'
+import Community from 'Pages/Community'
+
+const Routes = () => (
+  <>
+    <Header />
+    <Wrapper>
+      <Container>
+        <Switch>
+          <PublicRoute exact path="/login" redirectTo="/home" component={Login} />
+          <PublicRoute exact path="/register" redirectTo="/home" component={Register} />
+
+          <PrivateRoute exact path="/home" redirectTo="/login" component={Home} />
+
+          <PrivateRoute exact path="/~:name" redirectTo="/login" component={Community} />
+
+          <PrivateRoute exact path="/story/preview/fork/:id" redirectTo="/login" component={ViewStory} />
+          <PrivateRoute exact path="/story/preview/clone/:id" redirectTo="/login" component={ViewStory} />
+          <PrivateRoute exact path="/story/preview/:id" redirectTo="/login" component={ViewStory} />
+          <PrivateRoute exact path="/story/revisions/:storyId/" redirectTo="/login" component={ViewRevisions} />
+          <PrivateRoute exact path="/story/revisions/:storyId/:revisionId" redirectTo="/login" component={ViewRevision} />
+
+          <PrivateRoute exact path="/story/create" redirectTo="/login" component={CreateStory} />
+          <PrivateRoute exact path="/story/edit/:id" redirectTo="/login" component={EditStory} />
+
+          <PrivateRoute exact path="/start" redirectTo="/login" component={Choose} />
+
+          <PrivateRoute exact path="/profile" redirectTo="/login" component={MyStories} />
+          <PrivateRoute exact path="/profile/settings" redirectTo="/login" component={ProfileSettings} />
+          <PrivateRoute exact path="/profile/contributions" redirectTo="/login" component={Contributions} />
+          <PrivateRoute exact path="/profile/contributions/diff/:id" redirectTo="/login" component={DiffReview} />
+        </Switch>
+      </Container>
+    </Wrapper>
+  </>
+)
+
+export default Routes

--- a/yarn.lock
+++ b/yarn.lock
@@ -3047,6 +3047,10 @@ dom-testing-library@^3.9.0:
     pretty-format "^23.6.0"
     wait-for-expect "^1.0.0"
 
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -3810,7 +3814,7 @@ fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
@@ -4272,6 +4276,13 @@ global-dirs@^0.1.0:
 global-modules-path@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/global-modules-path/-/global-modules-path-2.3.0.tgz#b0e2bac6beac39745f7db5c59d26a36a0b94f7dc"
+
+global@^4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
 
 globals@^11.1.0, globals@^11.7.0:
   version "11.7.0"
@@ -6114,6 +6125,10 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.merge@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
+
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
@@ -6432,6 +6447,12 @@ mimic-fn@^1.0.0:
 mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
+
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  dependencies:
+    dom-walk "^0.1.0"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -7395,6 +7416,10 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
@@ -7598,6 +7623,20 @@ react-emotion@^9.2.12:
     babel-plugin-emotion "^9.2.11"
     create-emotion-styled "^9.2.8"
 
+react-hot-loader@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.6.0.tgz#7a556efea51a3c79e8bffdb094fbe17883a79432"
+  dependencies:
+    fast-levenshtein "^2.0.6"
+    global "^4.3.0"
+    hoist-non-react-statics "^2.5.0"
+    loader-utils "^1.1.0"
+    lodash.merge "^4.6.1"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
+    shallowequal "^1.0.2"
+    source-map "^0.7.3"
+
 react-immutable-proptypes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz#023d6f39bb15c97c071e9e60d00d136eac5fa0b4"
@@ -7606,7 +7645,7 @@ react-is@^16.3.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
 
-react-lifecycles-compat@^3.0.2:
+react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
@@ -8217,6 +8256,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+shallowequal@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -8410,7 +8453,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
-source-map@^0.7.2:
+source-map@^0.7.2, source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
 


### PR DESCRIPTION
# Implement react-hot-loader

- [x] Add Packages
- [x] Pull Routes out from App
- [x] Test

## Caveats

Due to the usage of @observer elements, and MST losing its state during HMR, stores are not hot-loaded. If you change a store, you will have to manually refresh.

## Moving Forward

`ToastProvider` is sitting above the HMR 'fold' so to speak. The idea of having `ToastProvider` sit above the `Router` is to negate rerenders when/if toasts are displayed & the user navigates. _Any changes to the Provider will require a manual reload for the time being._ This is likely to be addressed soon.